### PR TITLE
Use `concat` for appended records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.1 (2020-06-15)
+# 1.0.2 (2020-06-15)
 
 * Fixes apex TXT record appendix ([5a7ed12](https://github.com/operatehappy/terraform-aws-route53-workmail-records/commit/5a7ed12))
 * updates resource name identifier (#11) ([d2997c8](https://github.com/operatehappy/terraform-aws-route53-workmail-records/commit/d2997c8)), closes [#11](https://github.com/operatehappy/terraform-aws-route53-workmail-records/issues/11)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, fetch the module from the [Terraform Registry](https://registry.terraform.
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
 | zone_id | ID of the DNS Zone to store Records in | `string` | n/a |
-| apex_txt_record_append | additional Domain Apex TXT Record data | `string` | `""` |
+| apex_txt_record_append | additional Domain Apex TXT Record data | `list(string)` | `[]` |
 | dmarc_record | DMARC TXT Record | `string` | `"v=DMARC1;p=quarantine;pct=100;fo=1;"` |
 | mx_priority | MX Priority | `string` | `10` |
 | record_ttl | TTL for all DNS records | `string` | `86400` |

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "aws_route53_record" "zone_apex_txt" {
   name    = local.zone_name
   type    = "TXT"
   ttl     = var.record_ttl
-  records = [local.zone_apex_txt_record]
+  records = local.zone_apex_txt_record
 }
 
 // DMARC record

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,6 @@ data "aws_route53_zone" "zone" {
 locals {
   mx_record            = "${var.mx_priority} inbound-smtp.${var.workmail_zone}.amazonaws.com."
   autodiscover_record  = "autodiscover.mail.${var.workmail_zone}.awsapps.com."
-  zone_apex_txt_record = "\"${var.spf_record}\" ${var.apex_txt_record_append}"
+  zone_apex_txt_record = concat(var.spf_record, var.apex_txt_record_append)
   zone_name            = data.aws_route53_zone.zone.name // NOTE: trailing period is added by data source
 }

--- a/variables.tf
+++ b/variables.tf
@@ -28,9 +28,9 @@ variable "spf_record" {
 }
 
 variable "apex_txt_record_append" {
-  type        = string
+  type        = list(string)
   description = "additional Domain Apex TXT Record data"
-  default     = ""
+  default     = []
 }
 
 variable "dmarc_record" {

--- a/variables.tf
+++ b/variables.tf
@@ -22,9 +22,9 @@ variable "mx_priority" {
 }
 
 variable "spf_record" {
-  type        = string
+  type        = list(string)
   description = "SPF TXT Record"
-  default     = "v=spf1 include:amazonses.com ~all;"
+  default     = ["v=spf1 include:amazonses.com ~all;"]
 }
 
 variable "apex_txt_record_append" {


### PR DESCRIPTION
`1.0.1` introduced a suboptimal way of dealing with appended data for the domain apex TXT record: it would just combine the strings, resulting in an error when supplying certain type of information.

In this PR, I am introducing `concat` to combine Workmail-specific data and additional records into a single list (from two separate lists).

`README.md` and `variables.tf` have been updated, too.