### PR TITLE
Adds outputs for domain identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Use `concat` for appended records (#13) ([e0d4587](https://github.com/operatehappy/terraform-aws-route53-workmail-records/commit/e0d4587)), closes [#13](https://github.com/operatehappy/terraform-aws-route53-workmail-records/issues/13)
 * updates resource name identifier (#11) ([d2997c8](https://github.com/operatehappy/terraform-aws-route53-workmail-records/commit/d2997c8)), closes [#11](https://github.com/operatehappy/terraform-aws-route53-workmail-records/issues/11)
 
-# 1.0.0 (2020-06-11)
+## 1.0.0 (2020-06-11)
 
 * bumps version ([c2b1c1b](https://github.com/operatehappy/terraform-aws-route53-workmail-records/commit/c2b1c1b))
 * EOF fixes ([429bf53](https://github.com/operatehappy/terraform-aws-route53-workmail-records/commit/429bf53))

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Then, fetch the module from the [Terraform Registry](https://registry.terraform.
 | mx_record | interpolated value of `local.mx_record` |
 | zone_apex_txt_record | interpolated value of `aws_route53_record.zone-apex-txt.name` |
 | zone_name | interpolated value of `local.zone_name` |
+| domain_identity_arn | interpolated value of `aws_ses_domain_identity.identity.arn` |
+| domain_identity_verification_token | interpolated value of `aws_ses_domain_identity.identity.verification_token` |
 
 ## Author Information
 

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_route53_record" "verification_token" {
   name    = "_amazonses.${local.zone_name}"
   type    = "TXT"
   ttl     = "600"
-  records = ["${aws_ses_domain_identity.identity.verification_token}"]
+  records = [aws_ses_domain_identity.identity.verification_token]
 }
 
 // DKIM

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,13 @@ output "zone_name" {
   value       = local.zone_name
   description = "interpolated value of `local.zone_name`"
 }
+
+output "domain_identity_arn" {
+  value       = aws_ses_domain_identity.identity.arn
+  description = "interpolated value of `aws_ses_domain_identity.identity.arn`"
+}
+
+output "domain_identity_verification_token" {
+  value       = aws_ses_domain_identity.identity.verification_token
+  description = "interpolated value of `aws_ses_domain_identity.identity.verification_token`"
+}


### PR DESCRIPTION
This PR adds outputs for `domain_identity_arn` and `domain_identity_verification_token`, both of which I ended up needing for a downstream project. 