### PR TITLE
Updates Versions

### DIFF
--- a/.github/workflows/code-quality-terraform.yml
+++ b/.github/workflows/code-quality-terraform.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  TERRAFORM_VERSION: 0.12.20
+  TERRAFORM_VERSION: 0.13.2
   TERRAFORM_ACTIONS_COMMENT: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Adds outputs for domain identity (#14) ([20ca22f](https://github.com/operatehappy/terraform-aws-route53-workmail-records/commit/20ca22f)), closes [#14](https://github.com/operatehappy/terraform-aws-route53-workmail-records/issues/14)
 
-# 1.0.2 (2020-06-15)
+## 1.0.2 (2020-06-15)
 
 * Use `concat` for appended records (#13) ([e0d4587](https://github.com/operatehappy/terraform-aws-route53-workmail-records/commit/e0d4587)), closes [#13](https://github.com/operatehappy/terraform-aws-route53-workmail-records/issues/13)
 * updates resource name identifier (#11) ([d2997c8](https://github.com/operatehappy/terraform-aws-route53-workmail-records/commit/d2997c8)), closes [#11](https://github.com/operatehappy/terraform-aws-route53-workmail-records/issues/11)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Requirements
 
-This module requires Terraform version `0.12.0` or newer.
+This module requires Terraform version `0.13.0` or newer.
 
 ## Dependencies
 
@@ -29,7 +29,7 @@ Add the module to your Terraform resources like so:
 ```hcl
 module "workmail_records" {
   source           = "operatehappy/route53-workmail-records/aws"
-  version          = "1.0.3"
+  version          = "1.1.0"
   zone_id          = "Z3P5QSUBK4POTI"
   workmail_zone    = "us-west-2"
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = "> 2.10.0"

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "> 2.10.0"
+    aws = ">= 3.4.0"
   }
 }


### PR DESCRIPTION
This PR updates the underlying version of Terraform (`0.12.20` to `0.13.2`) and the AWS Provider (to `3.4.0`)

I intend to release this as `1.1.0`